### PR TITLE
Set contentType for PAM REST API request

### DIFF
--- a/Privileged-Access-Management-Portal/src/js/pamRestApi.js
+++ b/Privileged-Access-Management-Portal/src/js/pamRestApi.js
@@ -27,6 +27,7 @@ function createPamRequest(reqJustification, reqRoleId, reqTTL, reqTime) {
         url: BuildPamRestApiUrl('pamrequests'),
         type: 'POST',
         data: requestJson,
+		contentType: 'application/x-www-form-urlencoded',  //Role activation fails with HTTP 406 due to missing contentType
         xhrFields: {
             withCredentials: true
         }


### PR DESCRIPTION
Added contentType to AJAX request to resolve HTTP 406 error.